### PR TITLE
Add schema.json route to Rails generator

### DIFF
--- a/lib/generators/graphql/install_generator.rb
+++ b/lib/generators/graphql/install_generator.rb
@@ -100,6 +100,7 @@ RUBY
 
         template("graphql_controller.erb", "app/controllers/graphql_controller.rb")
         route('post "/graphql", to: "graphql#execute"')
+        route('get "/graphql/schema.json", to: "graphql#schema"')
 
         if options[:batch]
           gem("graphql-batch")

--- a/lib/generators/graphql/templates/graphql_controller.erb
+++ b/lib/generators/graphql/templates/graphql_controller.erb
@@ -11,6 +11,11 @@ class GraphqlController < ApplicationController
     render json: result
   end
 
+  def schema
+    result = <%= schema_name %>.execute(GraphQL::Introspection::INTROSPECTION_QUERY)
+    render json: result
+  end
+
   private
 
   # Handle form data, JSON body, or a blank value


### PR DESCRIPTION
>  _WIP: Looking for feedback to gauge if it's worth continuing this effort._

We've been using the result of `GraphQL::Introspection::INTROSPECTION_QUERY` to easily retrieve the complete schema.
We normally serve it from `GET /graphql/schema.json`, which allows you to fetch it from our web-browser if needed, without fiddling with `POST` requests, or having to create the non-trivial full introspection query.

There's more work to do here:
- [ ] Make this feature optional
- [ ] Add tests

If this seems like something valuable to add to the generator, I'll polish it up.
